### PR TITLE
Move db creds out of source code

### DIFF
--- a/db_info.php
+++ b/db_info.php
@@ -1,51 +1,13 @@
 <?php
-//open db
-$db = new PDO('mysql:host=localhost;dbname=bento_journal', 'bento_user', 'jfR7T0Bm');
-	$db->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
+// get credentials from outside of root directory
+$config = parse_ini_file(__DIR__ . '/../private_html/db_config.ini');
 
-/*
+// open db
+$db = new PDO('mysql:host=' . $config['servername'] . ';dbname=' . $config['dbname'], 
+	$config['username'], 
+	$config['password']);
 
-TABLE STRUCTURE
--------------------------------------------------------------------------------	
+$db->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
 
-
-	
-CREATE TABLE `entries` (
- `logid` int(11) NOT NULL AUTO_INCREMENT,
- `title` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
- `log` varchar(5000) COLLATE utf8_unicode_ci NOT NULL,
- `userid` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
- `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
- PRIMARY KEY (`logid`)
-) ;
-
-
-	
-CREATE TABLE `users` (
- `user_name` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
- `create_date` datetime DEFAULT NULL,
- `password` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
- `first_name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
- `last_name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
- `street` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
- `city` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
- `prov` char(2) COLLATE utf8_unicode_ci DEFAULT NULL,
- `postalcode` char(7) COLLATE utf8_unicode_ci DEFAULT NULL,
- `phone` varchar(50) COLLATE utf8_unicode_ci DEFAULT NULL,
- `email` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
- `isAdmin` int(11) NOT NULL,
- PRIMARY KEY (`user_name`)
-) ;
-
-CREATE TABLE `messages` (
- `msgid` int(11) NOT NULL AUTO_INCREMENT,
- `msg` varchar(140) COLLATE utf8_unicode_ci NOT NULL,
- `username` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
- `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
- PRIMARY KEY (`msgid`)
-);
-
-
-*/
 ?>
 

--- a/sample/db_config.ini
+++ b/sample/db_config.ini
@@ -1,0 +1,8 @@
+; This file is used to privately store the database credentials for the message board
+; Modify and place in ../private_html
+
+[database]
+servername = localhost
+dbname = message_board
+username = my_user_name
+password = my_password

--- a/sample/db_schema.sql
+++ b/sample/db_schema.sql
@@ -1,0 +1,37 @@
+-- This file can be used to initialize a MySQL database for the messageboard
+
+CREATE DATABASE message_board;
+USE message_board;
+
+CREATE TABLE `entries` (
+ `logid` int(11) NOT NULL AUTO_INCREMENT,
+ `title` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+ `log` varchar(5000) COLLATE utf8_unicode_ci NOT NULL,
+ `userid` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+ `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ PRIMARY KEY (`logid`)
+);
+
+CREATE TABLE `users` (
+ `user_name` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+ `create_date` datetime DEFAULT NULL,
+ `password` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
+ `first_name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
+ `last_name` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
+ `street` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
+ `city` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
+ `prov` char(2) COLLATE utf8_unicode_ci DEFAULT NULL,
+ `postalcode` char(7) COLLATE utf8_unicode_ci DEFAULT NULL,
+ `phone` varchar(50) COLLATE utf8_unicode_ci DEFAULT NULL,
+ `email` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+ `isAdmin` int(11) NOT NULL,
+ PRIMARY KEY (`user_name`)
+);
+
+CREATE TABLE `messages` (
+ `msgid` int(11) NOT NULL AUTO_INCREMENT,
+ `msg` varchar(140) COLLATE utf8_unicode_ci NOT NULL,
+ `username` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+ `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ PRIMARY KEY (`msgid`)
+);


### PR DESCRIPTION
For security, move db creds to private_html, just outside of root.
This also allows devs to use their own db to test messageboard.

See the end of [Setting up local dev environment](https://github.com/SmartCampusUWindsor/smart-campus/wiki/Setting-up-local-dev-environment) for info on how this would be used. If merged, when we redeploy we will need to create the private_html folder and db_config file. 